### PR TITLE
Reuse existing virtualenvs

### DIFF
--- a/travis_solo.py
+++ b/travis_solo.py
@@ -170,7 +170,7 @@ class Configuration(Structure):
 
 	def prepare_virtualenv(self):
 		if self.recreate:
-			self.rmtree(self.virtualenv_path)
+			self.rmtree(self.virtualenv_path, ignore_errors=True)
 		elif self.exists(self.virtualenv_path):
 			return
 

--- a/travis_solo_tests.py
+++ b/travis_solo_tests.py
@@ -111,9 +111,10 @@ class TestConfiguration(object):
 		self.check_call = Mock()
 		self.isdir = Mock()
 		self.environ = dict(PATH='/usr/bin', __PYVENV_LAUNCHER__='x')
+		self.exists = Mock()
 		self.rmtree = Mock()
 		self.configuration = Configuration(
-			python='2.7', variables=dict(A='a', B='x'), check_call=self.check_call, isdir=self.isdir, environ=self.environ, rmtree=self.rmtree)
+			python='2.7', variables=dict(A='a', B='x'), check_call=self.check_call, isdir=self.isdir, environ=self.environ, exists=self.exists, rmtree=self.rmtree)
 
 	def test_env_vars_are_set_before_running_a_build(self):
 		outer = self

--- a/travis_solo_tests.py
+++ b/travis_solo_tests.py
@@ -111,8 +111,9 @@ class TestConfiguration(object):
 		self.check_call = Mock()
 		self.isdir = Mock()
 		self.environ = dict(PATH='/usr/bin', __PYVENV_LAUNCHER__='x')
+		self.rmtree = Mock()
 		self.configuration = Configuration(
-			python='2.7', variables=dict(A='a', B='x'), check_call=self.check_call, isdir=self.isdir, environ=self.environ)
+			python='2.7', variables=dict(A='a', B='x'), check_call=self.check_call, isdir=self.isdir, environ=self.environ, rmtree=self.rmtree)
 
 	def test_env_vars_are_set_before_running_a_build(self):
 		outer = self


### PR DESCRIPTION
This speeds things up by reusing existing virtualenvs if they exist. It also adds the `--recreate` option mentioned in #2.
