### PR TITLE
Handle numbers in YAML file gracefully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ve/
 .travis-solo/
+__pycache__/
 dist/
 build/
 *.egg-info/

--- a/travis_solo.py
+++ b/travis_solo.py
@@ -288,7 +288,7 @@ class Loader(object):
 				build_matrix.remove(element)
 
 		configurations = tuple((
-			Configuration(python=p, variables=dict(v), base_path=join(getcwd(), '.travis-solo'), recreate=recreate)
+			Configuration(python=str(p), variables=dict(v), base_path=join(getcwd(), '.travis-solo'), recreate=recreate)
 			for (p, v) in build_matrix
 		))
 		allow_failures = matrix.get('allow_failures', [])

--- a/travis_solo_tests.py
+++ b/travis_solo_tests.py
@@ -4,7 +4,11 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from itertools import permutations
 from os.path import join
 
-from mock import Mock
+try:
+	from unittest.mock import Mock
+except ImportError:
+	from mock import Mock
+
 from nose.tools import eq_, ok_
 
 from travis_solo import Configuration, Loader, Runner, Step
@@ -73,6 +77,19 @@ class TestLoader(object):
 			Configuration(python='2.7', variables={'A': 'b'}, can_fail=True),
 			Configuration(python='3.3', variables={'A': 'b'}),
 			Configuration(python='2.7', variables={'A': 'c'}),
+		))
+
+	def test_loading_configurations_with_floating_point(self):
+		settings = dict(
+			language='python',
+			python=[2.7, '3.3']
+		)
+
+		configurations = self.loader.load_configurations(settings)
+
+		eq_(configurations, (
+			Configuration(python='2.7', variables={}),
+			Configuration(python='3.3', variables={}),
 		))
 
 class TestRunner(object):


### PR DESCRIPTION
This handles unquoted Python version numbers in `.travis.yml`. Previously, things like `2.7` instead of `"2.7"` would result in an error.

``` bash
$ travis-solo
'float' object has no attribute 'startswith'
```
